### PR TITLE
ci: build guest_accounts branch for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # ratchet:actions/checkout@v3
       with:
         repository: zedeus/nitter
-        ref: master
+        ref: guest_accounts
 
     - name: Get HEAD ref of Nitter
       run: |


### PR DESCRIPTION
Required until service for getting guest accounts is ready and available on main: https://github.com/zedeus/nitter/issues/983#issuecomment-1691602812