### PR TITLE
ci: move back to master for builds now that changes have been merged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,9 @@ jobs:
           fi
       - name: Setup Nim
         if: env.SKIP_BUILD == 'false'
-        uses: jiro4989/setup-nim-action@7867b7bd430d6f91e7ee54a70bd60e614b5b6c12 # ratchet:jiro4989/setup-nim-action@v1.4.7
+        uses: jiro4989/setup-nim-action@3a60cf06f20c1cf3a9becf76b30288c0361d5f1e # ratchet:jiro4989/setup-nim-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         if: env.SKIP_BUILD == 'false'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           repository: zedeus/nitter
-          ref: guest_accounts
+          ref: master
       - name: Get HEAD ref of Nitter
         run: |
           echo NITTER_COMMIT=$(git rev-parse --short HEAD) >> $GITHUB_ENV
@@ -49,7 +49,7 @@ jobs:
       - name: Build Nitter for AMD 64
         if: env.SKIP_BUILD == 'false'
         run: |
-          nimble build -y -d:release
+          nimble build -y -d:danger --mm:refc
           nimble scss
           nimble md
           cp nitter.example.conf nitter.conf
@@ -58,7 +58,7 @@ jobs:
       - name: Build Nitter for ARM 64
         if: env.SKIP_BUILD == 'false'
         run: |
-          nimble build -y -d:release --cpu:arm64
+          nimble build -y -d:danger --mm:refc --cpu:arm64
           tar -czvf nitter-arm64.tar.gz nitter public nitter.conf
       - name: Create Release Name
         if: env.SKIP_BUILD == 'false'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         if: env.SKIP_BUILD == 'false'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libsass-dev
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libsass-dev libpcre3 libpcre3-dev
       - name: Build Nitter for AMD 64
         if: env.SKIP_BUILD == 'false'
         run: |


### PR DESCRIPTION
Moving back to master following changes to auth being merged: https://github.com/zedeus/nitter/discussions/1212